### PR TITLE
Dynamic permissions

### DIFF
--- a/apps/news/manifest.php
+++ b/apps/news/manifest.php
@@ -4,10 +4,10 @@
 	<!-- Application name -->
 	<name>News</name>
 	
-	<version>0.3</version>
+	<version>0.4</version>
 	
 	<!-- Last update date -->
-	<date>19-04-2013</date>
+	<date>17-08-2013</date>
 	
 	<!-- Tiny icone to be displayed in the admin board -->
 	<icone></icone>
@@ -16,6 +16,11 @@
 	<permission name="news_editor" />
 	<permission name="global_editor" />
 	<permission name="deletor" />
+
+	<!-- Dynamic permissions -->
+	<dyn name="categories" table="news_cats" c-id="cid" c-parent="parent" c-name="name" />
+		<filter name="" model="lvl1/lvl2/cat_id" />
+	</dyn>
 	
 	<!-- Front pages -->
 	<action default="default">listing</action>

--- a/system/WCore/WController.php
+++ b/system/WCore/WController.php
@@ -97,11 +97,20 @@ abstract class WController {
 	 */
 	public final function forward($action, array $params = array()) {
 		if (!empty($action)) {
+			/*
+			 * Here will come the method call to check whether the user can execute this action with dynamic permissions using input values ($params)
+			 * Disallow if "strict"; Filter disallowed entries if "filter"
+			 * First, test if dynamic permissions are enabled on this site and not explicitly disabled on this application
+			 */
 			if ($this->hasAccess($this->getAppName(), $action)) {
 				// Execute action
 				if (method_exists($this, $action)) {
 					$this->action = $action;
 					
+					/*
+					 * Here will come the model (output) filtering
+					 */
+
 					return $this->$action($params);
 				} else {
 					return WNote::error('app_method_not_found', 'The method corresponding to the action "'.$action.'" cannot be found in '.$this->getAppName().' application.');
@@ -313,7 +322,10 @@ abstract class WController {
 								if (!isset($manifest['actions'][$key])) {
 									$manifest['actions'][$key] = array(
 										'desc' => isset($attributes['desc']) ? (string) $attributes['desc'] : $key,
-										'requires' => isset($attributes['requires']) ? array_map('trim', explode(',', $attributes['requires'])) : array()
+										'requires' => isset($attributes['requires']) ? array_map('trim', explode(',', $attributes['requires'])) : array()//,
+										/*
+										 * Here will come the dyn attributes to know which filter (strict or filter) we will have to use to filter this action
+										 */
 									);
 								}
 								if (isset($attributes['default']) && empty($manifest['default'])) {
@@ -379,6 +391,10 @@ abstract class WController {
 						}
 					}
 					break;
+
+				/*
+				 * Here will come the "dyn" initialization
+				 */
 				
 				case 'name':
 					$manifest['name'] = property_exists($xml, 'name') ? (string) $xml->name : basename(dirname($manifest_href));

--- a/system/WCore/WSession.php
+++ b/system/WCore/WSession.php
@@ -148,6 +148,9 @@ class WSession {
 					$app_name = substr($access, 0, $first_bracket);
 					$permissions = substr($access, $first_bracket+1, -1);
 					if (!empty($permissions)) {
+						/*
+						 * Here will come dynamic permissions grabbing
+						 */
 						$_SESSION['access'][$app_name] = explode('|', $permissions);
 					}
 				}
@@ -217,7 +220,7 @@ class WSession {
 	
 	/**
 	 * Generates a user-and-computer specific hash that will be stored in a cookie
-
+	 *
 	 * @param string $nick nickname
 	 * @param string $pass password
 	 * @param boolean $environment optional value: true if we want to use environnement specific values to generate the hash


### PR DESCRIPTION
A new big feature of WityCMS will be the ability to filter actions depending on any table of any application.

The developer has to define a table that will be used to filter (categories for news) and automagically the end-user will be able to use these categories to set permission (for example a user will be able to edit one category but not another).

Two step of filtering: 
- When accessing the application to avoid unallowed access to an action with a given category
- When sending the model (to the view or directly to the user) to remove unallowed output content

**TODO:** 
- [ ] Choose the manifest syntax to describe where is the data source in the database and where to filter it in the model
- [ ] Choose the manifest syntax to describe the filtering policy (input and/or output datas filtering and/or disallowing access)
- [ ] Choose the database storing syntax
- [ ] Implement the getter in WSession
- [ ] Implement the manifest parsing
- [ ] Implement the input filtering (similar to `hasAccess()`)
- [ ] Implement the output filtering
- [ ] Implement the GUI in the User application to easily edit these permissions

_The first commit of this branch show where these implementations could be done and give some possible ways to do it._

Related to #31 
